### PR TITLE
タイマを使用する場合を実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "editor.formatOnSave": true,
     "editor.formatOnType": true,
     "nrf-connect.toolchain.path": "${nrf-connect.toolchain:2.6.1}",
-    "nrf-connect.topdir": "${nrf-connect.sdk:2.6.1}"
+    "nrf-connect.topdir": "${nrf-connect.sdk:2.6.1}",
+    "nrf-connect.flash.softreset": true
 }

--- a/src/lib/mrubyc/hal.c
+++ b/src/lib/mrubyc/hal.c
@@ -13,28 +13,38 @@ static uint8_t memory_pool[MEMORY_SIZE];
 
 /* ===== prototype ===== */
 static int mrubyc_halinit(void);
-static int mrubyc_halmain(void);
 void mrubyc_haltick(struct k_work *const work);
 
 /* ===== kernel ===== */
 SYS_INIT(mrubyc_halinit, APPLICATION, 0);
 K_WORK_DEFINE(mrubyc_work, mrubyc_haltick);
-K_THREAD_DEFINE(mrubyc_thread, 384, mrubyc_halmain, NULL, NULL, NULL, -2,
-                K_ESSENTIAL, 0);
 
-/* ===== mrubyc_halinit ===== */
-static int mrubyc_halinit(void) {
-  mrbc_init(memory_pool, MEMORY_SIZE);
-  return EXIT_SUCCESS;
+#if !defined(MRBC_NO_TIMER)
+/* ===== use timer ===== */
+static void mrubyc_timerhandler(struct k_timer *const timer) {
+  k_work_submit(&mrubyc_work);
 }
-
-/* ===== mrubyc_halmain ===== */
+K_TIMER_DEFINE(mrubyc_timer, mrubyc_timerhandler, NULL);
+#else
+/* ===== MRBC_NO_TIMER ===== */
 static int mrubyc_halmain(void) {
   while (1) {
     k_work_submit(&mrubyc_work);
     k_msleep(1);
   }
   return EXIT_FAILURE;
+}
+K_THREAD_DEFINE(mrubyc_thread, 384, mrubyc_halmain, NULL, NULL, NULL, -2,
+                K_ESSENTIAL, 0);
+#endif
+
+/* ===== mrubyc_halinit ===== */
+static int mrubyc_halinit(void) {
+  mrbc_init(memory_pool, MEMORY_SIZE);
+#if !defined(MRBC_NO_TIMER)
+  k_timer_start(&mrubyc_timer, K_NO_WAIT, K_MSEC(1));
+#endif
+  return EXIT_SUCCESS;
 }
 
 /* ===== mrubyc_haltick ===== */


### PR DESCRIPTION
### タイマ使用
~~~console
Memory region         Used Size  Region Size  %age Used
           FLASH:      121016 B       512 KB     23.08%
             RAM:         32 KB        64 KB     50.00%
        IDT_LIST:          0 GB        32 KB      0.00%
~~~

### タイマなし (MRBC_NO_TIMER)
~~~console
Memory region         Used Size  Region Size  %age Used
           FLASH:      121052 B       512 KB     23.09%
             RAM:       33280 B        64 KB     50.78%
        IDT_LIST:          0 GB        32 KB      0.00%
~~~