### PR TITLE
オーバヘッド低減

### DIFF
--- a/src/lib/mrubyc/hal.c
+++ b/src/lib/mrubyc/hal.c
@@ -29,20 +29,20 @@ void hal_disable_irq(void) {
   k_sched_lock();
   hal_irq_lock_key = irq_lock();
 }
-static void mrubyc_timerhandler(struct k_timer *const timer) { mrbc_tick(); }
-K_TIMER_DEFINE(mrubyc_timer, mrubyc_timerhandler, NULL);
+static void mrubyc_haltimerhandler(struct k_timer *const timer) { mrbc_tick(); }
+K_TIMER_DEFINE(mrubyc_haltimer, mrubyc_haltimerhandler, NULL);
 #else
 /* ===== MRBC_NO_TIMER ===== */
 void mrubyc_haltick(struct k_work *const work) { mrbc_tick(); }
-K_WORK_DEFINE(mrubyc_work, mrubyc_haltick);
+K_WORK_DEFINE(mrubyc_halwork, mrubyc_haltick);
 static int mrubyc_halmain(void) {
   while (1) {
-    k_work_submit(&mrubyc_work);
+    k_work_submit(&mrubyc_halwork);
     k_msleep(1);
   }
   return EXIT_FAILURE;
 }
-K_THREAD_DEFINE(mrubyc_thread, 384, mrubyc_halmain, NULL, NULL, NULL, -2,
+K_THREAD_DEFINE(mrubyc_halthread, 384, mrubyc_halmain, NULL, NULL, NULL, -2,
                 K_ESSENTIAL, 0);
 #endif
 
@@ -50,7 +50,7 @@ K_THREAD_DEFINE(mrubyc_thread, 384, mrubyc_halmain, NULL, NULL, NULL, -2,
 static int mrubyc_halinit(void) {
   mrbc_init(memory_pool, MEMORY_SIZE);
 #if !defined(MRBC_NO_TIMER)
-  k_timer_start(&mrubyc_timer, K_NO_WAIT, K_MSEC(1));
+  k_timer_start(&mrubyc_haltimer, K_NO_WAIT, K_MSEC(1));
 #endif
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
タイマ使用時はワークキューを使用しない

## タイマ使用時
### 改修前
```console
Memory region         Used Size  Region Size  %age Used
           FLASH:      122852 B       512 KB     23.43%
             RAM:       34368 B        64 KB     52.44%
        IDT_LIST:          0 GB        32 KB      0.00%


Thread analyze:
 thread_analyzer     : STACK: unused 592 usage 432 / 1024 (42 %); CPU: 0 %
      : Total CPU cycles used: 182
 sysworkq            : STACK: unused 864 usage 160 / 1024 (15 %); CPU: 2 %
      : Total CPU cycles used: 19051
 logging             : STACK: unused 208 usage 560 / 768 (72 %); CPU: 0 %
      : Total CPU cycles used: 352
 idle                : STACK: unused 272 usage 48 / 320 (15 %); CPU: 94 %
      : Total CPU cycles used: 598534
 main                : STACK: unused 576 usage 448 / 1024 (43 %); CPU: 2 %
      : Total CPU cycles used: 18542
 ISR0                : STACK: unused 1648 usage 400 / 2048 (19 %)
```


### 改修後
```console
Memory region         Used Size  Region Size  %age Used
           FLASH:      121784 B       512 KB     23.23%
             RAM:       33024 B        64 KB     50.39%
        IDT_LIST:          0 GB        32 KB      0.00%


Thread analyze:
 thread_analyzer     : STACK: unused 592 usage 432 / 1024 (42 %); CPU: 0 %
      : Total CPU cycles used: 114
 logging             : STACK: unused 208 usage 560 / 768 (72 %); CPU: 0 %
      : Total CPU cycles used: 218
 idle                : STACK: unused 272 usage 48 / 320 (15 %); CPU: 97 %
      : Total CPU cycles used: 477728
 main                : STACK: unused 576 usage 448 / 1024 (43 %); CPU: 2 %
      : Total CPU cycles used: 13712
 ISR0                : STACK: unused 1648 usage 400 / 2048 (19 %)
```


## タイマ非使用時（MRBC_NO_TIMER）
### 改修前
```console
Memory region         Used Size  Region Size  %age Used
           FLASH:      122856 B       512 KB     23.43%
             RAM:       34944 B        64 KB     53.32%
        IDT_LIST:          0 GB        32 KB      0.00%


Thread analyze:
 thread_analyzer     : STACK: unused 592 usage 432 / 1024 (42 %); CPU: 0 %
      : Total CPU cycles used: 105
 mrubyc_thread       : STACK: unused 176 usage 208 / 384 (54 %); CPU: 1 %
      : Total CPU cycles used: 4872
 sysworkq            : STACK: unused 864 usage 160 / 1024 (15 %); CPU: 2 %
      : Total CPU cycles used: 7174
 logging             : STACK: unused 280 usage 488 / 768 (63 %); CPU: 0 %
      : Total CPU cycles used: 201
 idle                : STACK: unused 272 usage 48 / 320 (15 %); CPU: 93 %
      : Total CPU cycles used: 288342
 main                : STACK: unused 584 usage 440 / 1024 (42 %); CPU: 2 %
      : Total CPU cycles used: 9201
 ISR0                : STACK: unused 1648 usage 400 / 2048 (19 %)
```


### 改修後
```console
Memory region         Used Size  Region Size  %age Used
           FLASH:      122856 B       512 KB     23.43%
             RAM:       34944 B        64 KB     53.32%
        IDT_LIST:          0 GB        32 KB      0.00%

Thread analyze:
 thread_analyzer     : STACK: unused 592 usage 432 / 1024 (42 %); CPU: 0 %
      : Total CPU cycles used: 599
 mrubyc_thread       : STACK: unused 176 usage 208 / 384 (54 %); CPU: 1 %
      : Total CPU cycles used: 25303
 sysworkq            : STACK: unused 864 usage 160 / 1024 (15 %); CPU: 3 %
      : Total CPU cycles used: 68837
 logging             : STACK: unused 208 usage 560 / 768 (72 %); CPU: 0 %
      : Total CPU cycles used: 1170
 idle                : STACK: unused 272 usage 48 / 320 (15 %); CPU: 91 %
      : Total CPU cycles used: 1707949
 main                : STACK: unused 584 usage 440 / 1024 (42 %); CPU: 2 %
      : Total CPU cycles used: 54563
 ISR0                : STACK: unused 1648 usage 400 / 2048 (19 %)
```